### PR TITLE
Update support from Stacks and drop Edge Legacy assets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,13 +5,13 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "browserslist-viewer",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@browser-logos/android": "^1.0.11",
         "@browser-logos/chrome": "^1.0.18",
         "@browser-logos/edge": "^2.0.5",
-        "@browser-logos/edge_12-18": "^1.0.2",
         "@browser-logos/firefox": "^3.0.9",
         "@browser-logos/internet-explorer_9-11": "^1.1.15",
         "@browser-logos/opera": "^1.1.11",
@@ -19,7 +19,7 @@
         "@browser-logos/safari-ios": "^1.0.15",
         "@browser-logos/samsung-internet": "^4.0.6",
         "@browser-logos/uc": "^1.0.7",
-        "@stackoverflow/stacks": "^0.63.2",
+        "@stackoverflow/stacks": "^0.64.0",
         "browserslist": "^4.16.5",
         "caniuse-lite": "^1.0.30001219"
       },
@@ -82,11 +82,6 @@
       "resolved": "https://registry.npmjs.org/@browser-logos/edge/-/edge-2.0.5.tgz",
       "integrity": "sha512-5eEA9FQw8wxLruWSygbwadtYhvr9RS3nZI7M6tSxIoxcMgpDZ4npbkDCJ5+QXYuCriQAsKeQKX+tW6u2wWJMvg=="
     },
-    "node_modules/@browser-logos/edge_12-18": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@browser-logos/edge_12-18/-/edge_12-18-1.0.2.tgz",
-      "integrity": "sha512-lkxF/e2UcIu0hEk2FwhS4IeQ5NvGqzX8o1XLsSZnoINwVbZUfNFTzifNT/1H4oQ3LsNGYgX3TSQ2eWSsl6oDNA=="
-    },
     "node_modules/@browser-logos/firefox": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/@browser-logos/firefox/-/firefox-3.0.9.tgz",
@@ -141,9 +136,9 @@
       }
     },
     "node_modules/@stackoverflow/stacks": {
-      "version": "0.63.2",
-      "resolved": "https://registry.npmjs.org/@stackoverflow/stacks/-/stacks-0.63.2.tgz",
-      "integrity": "sha512-mt8c+2DTb0h5aqW0jMwfL24aKjDtasgksJFI6bmTIH98aUx0s1mOnZl2Q1CLP3DCQfLqVSYxUrKUVxlL2s16mQ==",
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@stackoverflow/stacks/-/stacks-0.64.0.tgz",
+      "integrity": "sha512-krMJk30jVxbc9nYBTumbhYPBn+F0aOByS6I73W5kHcUHeHEd6IRqCPnG5dvZA479yYUw9rrHdWeQPStWC4gOFg==",
       "dependencies": {
         "@popperjs/core": "^2.9.2",
         "stimulus": "^1.1.1"
@@ -7586,7 +7581,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -8158,11 +8152,6 @@
       "resolved": "https://registry.npmjs.org/@browser-logos/edge/-/edge-2.0.5.tgz",
       "integrity": "sha512-5eEA9FQw8wxLruWSygbwadtYhvr9RS3nZI7M6tSxIoxcMgpDZ4npbkDCJ5+QXYuCriQAsKeQKX+tW6u2wWJMvg=="
     },
-    "@browser-logos/edge_12-18": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@browser-logos/edge_12-18/-/edge_12-18-1.0.2.tgz",
-      "integrity": "sha512-lkxF/e2UcIu0hEk2FwhS4IeQ5NvGqzX8o1XLsSZnoINwVbZUfNFTzifNT/1H4oQ3LsNGYgX3TSQ2eWSsl6oDNA=="
-    },
     "@browser-logos/firefox": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/@browser-logos/firefox/-/firefox-3.0.9.tgz",
@@ -8210,9 +8199,9 @@
       "integrity": "sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q=="
     },
     "@stackoverflow/stacks": {
-      "version": "0.63.2",
-      "resolved": "https://registry.npmjs.org/@stackoverflow/stacks/-/stacks-0.63.2.tgz",
-      "integrity": "sha512-mt8c+2DTb0h5aqW0jMwfL24aKjDtasgksJFI6bmTIH98aUx0s1mOnZl2Q1CLP3DCQfLqVSYxUrKUVxlL2s16mQ==",
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@stackoverflow/stacks/-/stacks-0.64.0.tgz",
+      "integrity": "sha512-krMJk30jVxbc9nYBTumbhYPBn+F0aOByS6I73W5kHcUHeHEd6IRqCPnG5dvZA479yYUw9rrHdWeQPStWC4gOFg==",
       "requires": {
         "@popperjs/core": "^2.9.2",
         "stimulus": "^1.1.1"
@@ -12281,7 +12270,6 @@
       "dev": true,
       "requires": {
         "purgecss": "^4.0.3",
-        "webpack": "^5.4.0",
         "webpack-sources": "^2.0.0"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@browser-logos/safari-ios": "^1.0.15",
     "@browser-logos/samsung-internet": "^4.0.6",
     "@browser-logos/uc": "^1.0.7",
-    "@stackoverflow/stacks": "^0.63.2",
+    "@stackoverflow/stacks": "^0.64.0",
     "browserslist": "^4.16.5",
     "caniuse-lite": "^1.0.30001219"
   }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@browser-logos/android": "^1.0.11",
     "@browser-logos/chrome": "^1.0.18",
     "@browser-logos/edge": "^2.0.5",
-    "@browser-logos/edge_12-18": "^1.0.2",
     "@browser-logos/firefox": "^3.0.9",
     "@browser-logos/internet-explorer_9-11": "^1.1.15",
     "@browser-logos/opera": "^1.1.11",

--- a/public/index.css
+++ b/public/index.css
@@ -10,10 +10,6 @@
     background-image: url("~@browser-logos/edge/edge_32x32.png");
 }
 
-.browser-image.edge-legacy {
-    background-image: url("~@browser-logos/edge_12-18/edge_12-18_32x32.png");
-}
-
 .browser-image.chrome {
     background-image: url("~@browser-logos/chrome/chrome_32x32.png");
 }


### PR DESCRIPTION
What it says in the title. Bumps Stacks to `0.64.0` while killing the Edge Legacy assets.