### PR TITLE
prevent duplicate autocomplete initialization on first interaction

### DIFF
--- a/.github/workflows/auto-upgrade-caniuse-lite.yml
+++ b/.github/workflows/auto-upgrade-caniuse-lite.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Fetch dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v1
+        uses: dependabot/fetch-metadata@v2
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Auto Merge Dependabot PRs for caniuse-lite

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -12,7 +12,7 @@ jobs:
         steps:
             - name: Dependabot metadata
               id: metadata
-              uses: dependabot/fetch-metadata@v1
+              uses: dependabot/fetch-metadata@v2
               with:
                   github-token: "${{ secrets.GITHUB_TOKEN }}"
             - name: Enable auto-merge for Dependabot PRs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,12 +10,13 @@ jobs:
     build-test:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
             - name: Setup Node.js environment
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: lts/*
+                  cache: npm
 
             - name: Install dependencies
               run: npm ci

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,15 +77,18 @@ async function updateSupportedStatusAsync(feature: string) {
         });
 }
 
+// Guards against re-entrant initialization. A single click focuses the input
+// *and* bubbles a click to the container, firing both listeners below; the
+// previous DOM-attribute check was set asynchronously (after the dynamic
+// import resolved), so both calls slipped through and created two instances.
+let autocompleteInitialized = false;
+
 async function initializeAutocomplete(): Promise<void> {
-    if (
-        document
-            .querySelector(".js-autocomplete-input")
-            ?.getAttribute("type") === "search"
-    ) {
-        // already initialized, exit early
+    if (autocompleteInitialized) {
+        // already initializing or initialized, exit early
         return;
     }
+    autocompleteInitialized = true;
 
     const Autocomplete = await loadAutocompleteAsync();
 


### PR DESCRIPTION
Hi StackExchange, 

Two independent fixes:

1. **fix:** the autocomplete initializes twice on the first click, creating two `Autocomplete` instances bound to the same input.
2. **ci:** the GitHub Actions workflows pin deprecated action versions running on the Node 16 runtime.

Both are small and self-contained; they're split into separate commits.

## 1. Duplicate autocomplete initialization

### Problem

The autocomplete is lazy-loaded on first interaction, with two `{ once: true }` listeners:

- a `click` listener on `.js-autocomplete-container`
- a `focus` listener on the input inside it

A single mouse click on the input fires **both**: focus fires on mousedown, then the click bubbles up to the container. Both call `initializeAutocomplete()`.

The existing guard was meant to dedupe:

```ts
if (document.querySelector(".js-autocomplete-input")?.getAttribute("type") === "search") {
    return; // already initialized
}
```

But `type="search"` is only set by Algolia **after** the dynamic `import()` of the autocomplete module resolves, which is asynchronous. So when both listeners fire in the same gesture, both calls pass the guard before either finishes importing, and two instances get constructed on the same input (duplicate event listeners, double submits). Keyboard/tab users avoid it (focus only, no click); mouse users hit it on the first click.

### Fix

Replace the async DOM-attribute check with a synchronous boolean set before the first `await`, so a re-entrant call returns immediately:

```ts
let autocompleteInitialized = false;

async function initializeAutocomplete(): Promise<void> {
    if (autocompleteInitialized) {
        return;
    }
    autocompleteInitialized = true;

    const Autocomplete = await loadAutocompleteAsync();
    // ...
}
```

## 2. Deprecated GitHub Actions

### Problem

`.github/workflows/main.yml` pins `actions/checkout@v3` and `actions/setup-node@v3`, both of which run on the Node 16 runtime that GitHub has deprecated. They emit deprecation warnings in CI today and are on a removal path. The two dependabot workflows pin `dependabot/fetch-metadata@v1`, likewise superseded by v2.

### Fix

- `actions/checkout@v3` -> `@v4`
- `actions/setup-node@v3` -> `@v4`, plus `cache: npm` (the repo has a lockfile and uses `npm ci`, so this is a free CI speedup)
- `dependabot/fetch-metadata@v1` -> `@v2` in both `auto-upgrade-caniuse-lite.yml` and `dependabot-auto-merge.yml`

The `fetch-metadata` v2 bump is drop-in (same outputs).

## Testing

- `npm ci && npm run build` passes locally.
- The autocomplete fix was verified against the interaction that triggers it (clicking the input rather than tabbing to it).

## Notes / out of scope

While reviewing I also noticed `helpers/static-data.ts` types `imageUrl` as `string` but `logoMapping` only covers seven browsers, so any browser not in the map would render `<img src="">`. I confirmed this does **not** currently trigger: the `@stackoverflow/browserslist-config` query explicitly excludes every unmapped browser, so the resolved set is exactly the seven that are mapped. Left it alone to keep this PR focused; happy to add a guard in a follow-up if you'd prefer the hardening.